### PR TITLE
embedding refactor and Voyager support

### DIFF
--- a/configs/embedding_config.yaml
+++ b/configs/embedding_config.yaml
@@ -1,13 +1,15 @@
 text:
   type: cloud
   dim: 1024
-  provider: openai
-  model_name: text-embedding-3-large
-  api_key_path: "configs/openai_key.yaml"
+  provider: voyager
+  model_name: voyage-3-large
+  max_tokens: 32000
+  api_key_path: "configs/voyager_api_key.yaml"
 
 code:
   type: cloud
   dim: 1024
-  provider: openai
-  model_name: text-embedding-3-large
-  api_key: "configs/openai_key.yaml"
+  provider: voyager
+  model_name: voyage-code-3
+  max_tokens: 16000
+  api_key_path: "configs/voyager_api_key.yaml"

--- a/configs/qdrant_config.yaml
+++ b/configs/qdrant_config.yaml
@@ -8,4 +8,5 @@ connection:
 collection_settings:
   distance_metric: "cosine"                  # Vector similarity metric: cosine, dot, euclid
   upsert_batch_size: 32
-  embedding_batch_size: 64
+  embedding_batch_size: 16
+  build_only_code: true

--- a/configs/voyager_api_key_EXAMPLE.yaml
+++ b/configs/voyager_api_key_EXAMPLE.yaml
@@ -1,0 +1,1 @@
+key: "YOUR_API_KEY"

--- a/main_build_db.py
+++ b/main_build_db.py
@@ -29,15 +29,19 @@ def main():
     )
     print("✅ Qdrant Vector DB Manager initialized")
 
-    print("\n🗑️ Deleting existing Qdrant DB (if any)...")
-    manager_qdrant_vector_db.delete_db()
-    print("✅ Database deleted")
+    print("Are you sure to delete db? Press Y")
+    user_input = input().strip()
+    if user_input == "Y":
+        print("\n🗑️ Deleting existing Qdrant DB (if any)...")
+        manager_qdrant_vector_db.delete_db()  # uncomment to actually delete
+        print("✅ Database deleted")
 
-    repo_dir = repos_config["path_to_repos"]
-    print(f"\n📂 Creating vector DB from directory: {repo_dir}")
-    manager_qdrant_vector_db.create_vector_db_from_dir(repo_dir)
-    print("✅ Vector DB created successfully")
-
+        repo_dir = repos_config["path_to_repos"]
+        print(f"\n📂 Creating vector DB from directory: {repo_dir}")
+        manager_qdrant_vector_db.create_vector_db_from_dir(repo_dir)
+        print("✅ Vector DB created successfully")
+    else:
+        print("❌ Aborted. Database not deleted.")
 
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ colorama
 tree_sitter==0.21.3
 tree_sitter_languages==1.10.2
 tiktoken
+voyageai

--- a/src/ast/metadata_extractor_manager.py
+++ b/src/ast/metadata_extractor_manager.py
@@ -25,6 +25,10 @@ class MetadataExtractorManager:
 
         self._ignore_patterns = [p for v in ignore_patterns_config.values() for p in v]
 
+        # TODO move it to config
+        self._max_file_size = 1024  # kb
+        self._max_file_length = 3000  # lines
+
     @execution_profiler
     def process_repo(self, repo_path) -> Dict[str, dict]:
         repo_path = Path(repo_path).resolve()
@@ -45,6 +49,11 @@ class MetadataExtractorManager:
             extractor = self._extractor_by_ext.get(suffix)
             if extractor is None:
                 # skip unknown extensions
+                continue
+
+            lines, size_kb = self._count_lines_and_size(str(file_path))
+            if lines > self._max_file_length or size_kb > self._max_file_size:
+                print(f"SKIP: {rel_path} (too big file: size {size_kb / 1024})")
                 continue
 
             try:
@@ -81,4 +90,13 @@ class MetadataExtractorManager:
 
         return results
 
-
+    @staticmethod
+    def _count_lines_and_size(path: str) -> tuple[int, float]:
+        p = Path(path)
+        size_bytes = p.stat().st_size
+        lines = 0
+        with p.open("rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                lines += chunk.count(b"\n")
+        size_kb = size_bytes / 1024
+        return lines, size_kb

--- a/src/embedding_module/embedding_abc.py
+++ b/src/embedding_module/embedding_abc.py
@@ -1,8 +1,7 @@
 from abc import ABC, abstractmethod
-from src.utils.helper import SingletonABCMeta
 
 
-class EmbeddingABC(ABC, metaclass=SingletonABCMeta):
+class EmbeddingABC(ABC):
     """Abstract base class for embedding models."""
 
     @abstractmethod

--- a/src/embedding_module/emmbeding_builder.py
+++ b/src/embedding_module/emmbeding_builder.py
@@ -1,7 +1,8 @@
 from typing import Dict, Any, Union, List
 from pathlib import Path
 from src.embedding_module.local_embedding import LocalEmbedding
-from src.embedding_module.cloud_embedding import CloudEmbedding
+from src.embedding_module.openai_embedding import OpenaiEmbedding
+from src.embedding_module.voyager_embedding import VoyagerEmbedding
 
 
 class EmbeddingBuilder:
@@ -30,7 +31,13 @@ class EmbeddingBuilder:
         if etype == "local":
             return LocalEmbedding(cfg)
         elif etype == "cloud":
-            return CloudEmbedding(cfg)
+            provider = cfg["provider"]
+            if provider == "openai":
+                return OpenaiEmbedding(cfg)
+            elif provider == "voyager":
+                return VoyagerEmbedding(cfg)
+            else:
+                raise ValueError(f"Unknown provider type: {provider}")
         else:
             raise ValueError(f"Unknown embedding type: {etype}")
 

--- a/src/embedding_module/openai_embedding.py
+++ b/src/embedding_module/openai_embedding.py
@@ -6,7 +6,7 @@ from src.utils.helper import load_yaml
 import os
 
 
-class CloudEmbedding(EmbeddingABC):
+class OpenaiEmbedding(EmbeddingABC):
     """Minimal OpenAI-only cloud embedding wrapper with dim validation."""
 
     def __init__(self, config: Dict[str, Any]):
@@ -27,7 +27,6 @@ class CloudEmbedding(EmbeddingABC):
             raise ValueError("OpenAI API key not found in config or OPENAI_API_KEY env")
 
         self.client = OpenAI(api_key=api_key)
-        self.batch_size = int(config.get("batch_size", 256))
         self.dim_size = int(config.get("dim")) if config.get("dim") is not None else None
 
         self.enc = tiktoken.get_encoding("cl100k_base")
@@ -38,20 +37,12 @@ class CloudEmbedding(EmbeddingABC):
         if len(items) == 0:
             return [] if isinstance(texts, list) else []
 
-        out: List[List[float]] = []
-        for i in range(0, len(items), self.batch_size):
-            batch = items[i : i + self.batch_size]
-            batch = self._trim_texts_to_max_tokens(batch)
-            resp = self.client.embeddings.create(model=self.model_name, input=batch, dimensions=self.dim_size)
-            for entry in resp.data:
-                vec = entry.embedding
-                if self.dim_size is not None and len(vec) != self.dim_size:
-                    raise ValueError(
-                        f"Embedding dimension mismatch: model returned {len(vec)} but config.dim={self.dim_size}"
-                    )
-                out.append(vec)
+        items = self._trim_texts_to_max_tokens(items)
+        resp = self.client.embeddings.create(model=self.model_name, input=items, dimensions=self.dim_size)
 
-        return out[0] if isinstance(texts, str) else out
+        embeds = [data.embedding for data in resp.data]
+
+        return embeds[0] if isinstance(texts, str) else embeds
 
 
     def _trim_texts_to_max_tokens(self, texts: List[str]) -> List[str]: # TODO ...

--- a/src/embedding_module/voyager_embedding.py
+++ b/src/embedding_module/voyager_embedding.py
@@ -1,0 +1,35 @@
+from typing import List, Dict, Any, Union
+import voyageai
+
+from src.embedding_module.embedding_abc import EmbeddingABC
+from src.utils.helper import load_yaml
+
+
+class VoyagerEmbedding(EmbeddingABC):
+    def __init__(self, config: Dict[str, Any]):
+        # Create Voyage client
+        self.client = voyageai.Client(api_key=load_yaml(config["api_key_path"])["key"])
+        self.model_name = config.get("model_name")
+        self.dim_size = int(config["dim"])
+        self.max_tokens = int(config["max_tokens"])
+
+    def embed(self, texts: Union[str, List[str]]) -> Union[List[float], List[List[float]]]:
+        items = self._ensure_list(texts)
+        if len(items) == 0:
+            return []
+
+        resp = self.client.embed(model=self.model_name,
+                                 texts=texts,
+                                 truncation=True,
+                                 output_dimension=self.dim_size)
+        embeds = getattr(resp, "embeddings", None)
+
+        return embeds[0] if isinstance(texts, str) else embeds
+
+    @staticmethod
+    def _ensure_list(x: Union[str, List[str]]) -> List[str]:
+        return [x] if isinstance(x, str) else list(x)
+
+
+
+

--- a/src/vector_db/manager_qdrant_vector_db.py
+++ b/src/vector_db/manager_qdrant_vector_db.py
@@ -25,6 +25,7 @@ class ManagerQdrantVectorDb:
         # Parse connection settings
         self.host_url: str = config["connection"]["url"]
         self.container_name: str = config["connection"].get("container_name", "qdrant")
+        self.build_only_code: bool = config["collection_settings"]["build_only_code"]
 
         # Derive port from host_url (assume format http://host:port)
         # self.port: int = int(self.host_url.split(":")[-1])
@@ -86,10 +87,10 @@ class ManagerQdrantVectorDb:
     @execution_profiler
     def create_vector_db_from_dir(self, root_repos_dir):
         repos_dir = [d for d in glob.glob(os.path.join(root_repos_dir, "*/")) if os.path.isdir(d)]
-        cnt = 0
+        # cnt = 0
         for repo_path in tqdm(map(Path, repos_dir), desc="Processing repos"):
             # cnt +=1
-            # if cnt < 110:
+            # if cnt < 134:
             #     continue
             repo_root = Path(repo_path).resolve()
             metadata_map = self.metadata_extractor_manager.process_repo(repo_root)
@@ -102,10 +103,11 @@ class ManagerQdrantVectorDb:
                 continue
 
             self._qdrant_vector_db.create_collection_with_data(docs,
+                                                               only_code=self.build_only_code,
                                                                overwrite_existing=True)  # TODO overwrite_existing?
 
     @execution_profiler
-    def search(self, query: str, top_k: int = 3, per_field: bool = True,
+    def search(self, query: str, top_k: int = 3, per_field: bool = False,
                positive_filter_conditions: dict = None,
                negative_filter_conditions: dict = None,
                diversity: bool = False): # TODO change to number like give at least 3 diversity repo
@@ -121,28 +123,35 @@ class ManagerQdrantVectorDb:
                                                         positive_filter_conditions=positive_filter_conditions,
                                                         negative_filter_conditions=negative_filter_conditions)
 
+        query_code_vector = self.embedding_model.code_embed(query)
+        if per_field:
+            query_doc_vector = self.embedding_model.text_embed(query)
+        else:
+            query_doc_vector = None
+
         all_hits = []
         # 3) Loop through collections
         for collection in filtered_collections:
             cname = collection.name
             hits = self._qdrant_vector_db.search_collection(
                 collection_name=cname,
-                query_text=query,
+                query_code_vector=query_code_vector,
+                query_doc_vector=query_doc_vector,
                 top_k=top_k,  # local top_k per collection
-                per_field=per_field,
             )
 
             # 4) Collect results with metadata
             for field, results in hits.items():
-                for hit in results:
-                    score = getattr(hit, "score", None)
-                    all_hits.append({
-                        "collection": cname,
-                        "field": field,
-                        "value": hit.payload["metadata"].get(field, "<missing>"),
-                        "score": score,
-                        "metadata": hit.payload
-                    })
+                if results:
+                    for hit in results:
+                        score = getattr(hit, "score", None)
+                        all_hits.append({
+                            "collection": cname,
+                            "field": field,
+                            "value": hit.payload["metadata"].get(field, "<missing>"),
+                            "score": score,
+                            "metadata": hit.payload
+                        })
 
         # 5) Keep only global top_k (with optional diversity)
         def _score(h):

--- a/src/vector_db/qdrant_vector_db.py
+++ b/src/vector_db/qdrant_vector_db.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import Dict, Optional, Sequence, Union, Any
 import uuid
 from tqdm import tqdm
+import numpy as np
 
 from qdrant_client import QdrantClient
 from qdrant_client.models import (
@@ -57,7 +58,7 @@ class QdrantVectorDB:
                 url=connection_cfg["url"],
                 api_key=load_yaml(connection_cfg["api_key_path"])["key"],
                 timeout=30,
-                prefer_grpc = True
+                prefer_grpc=True
             )
 
         # Embedding model
@@ -74,28 +75,27 @@ class QdrantVectorDB:
     def search_collection(
             self,
             collection_name: str,
-            query_text: str,
+            query_code_vector: np.ndarray,
+            query_doc_vector: np.ndarray,
             top_k: int = 5,
             filter_conditions: Optional[Dict[str, Union[str, int, float, bool]]] = None,
             include_payload: bool = True,
-            per_field: bool = False,  # ✅ new flag
     ):
-        query_code_vector = self.embedding_model.code_embed(query_text)
-        query_doc_vector = self.embedding_model.text_embed(query_text)
 
         query_filter = (
             self._build_eq_filter(filter_conditions) if filter_conditions else None
         )
 
-        if per_field:
-            # ✅ return top-k per field
-            code_results = self.qdrant_client.search(
-                collection_name=collection_name,
-                query_vector=("code_to_embedded", query_code_vector),
-                limit=top_k,
-                with_payload=include_payload,
-                query_filter=query_filter,
-            )
+        # ✅ return top-k per field
+        code_results = self.qdrant_client.search(
+            collection_name=collection_name,
+            query_vector=("code_to_embedded", query_code_vector),
+            limit=top_k,
+            with_payload=include_payload,
+            query_filter=query_filter,
+        )
+
+        if query_doc_vector:
             doc_results = self.qdrant_client.search(
                 collection_name=collection_name,
                 query_vector=("doc_to_embedded", query_doc_vector),
@@ -103,38 +103,31 @@ class QdrantVectorDB:
                 with_payload=include_payload,
                 query_filter=query_filter,
             )
-            return {"code": code_results, "doc": doc_results}
-
         else:
-            # ❌ Qdrant does not support multi-vector search directly.
-            # So here we just pick one field as "primary".
-            # Later we could implement weighted fusion.
-            return self.qdrant_client.search(
-                collection_name=collection_name,
-                query_vector=("code_to_embedded", query_code_vector),
-                limit=top_k,
-                with_payload=include_payload,
-                query_filter=query_filter,
-            )
+            doc_results = None
 
-    def set_collection_name(self, collection_name): # TODO remove self.collection_name , make it fully dynamic per project
+        return {"code": code_results, "doc": doc_results}
+
+    def set_collection_name(self,
+                            collection_name):  # TODO remove self.collection_name , make it fully dynamic per project
         self.collection_name = collection_name
 
     @execution_profiler
     def create_collection_with_data(
             self,
             documents: Sequence[Dict[str, Any]],
+            only_code: bool,
             overwrite_existing: bool = False,
             create_payload_indexes: bool = True,
     ) -> None:
         # Validate
-        embedding_keys = self._validate_documents(documents)
+        embedding_keys = self._validate_documents(documents, only_code)
 
         # Create/recreate collection
         vectors_config = self._ensure_collection(embedding_keys, overwrite_existing)
 
         # Prepare data
-        points = self._build_points(documents, embedding_keys, vectors_config)
+        points = self._build_points(documents, embedding_keys, vectors_config, only_code)
 
         # Upsert in batches of 100 with progress bar
         if points:
@@ -151,7 +144,7 @@ class QdrantVectorDB:
 
     # ------------- private helpers -------------
 
-    def _validate_documents(self, documents: Sequence[Dict[str, Any]]) -> set[str]:
+    def _validate_documents(self, documents: Sequence[Dict[str, Any]], only_code: bool) -> set[str]:
         if not documents:
             raise ValueError("No documents provided")
 
@@ -161,6 +154,10 @@ class QdrantVectorDB:
             for key in doc.keys()
             if key.endswith("_to_embedded")
         }
+
+        if only_code:
+            embedding_keys = {k for k in embedding_keys if "code" in k}
+
         if not embedding_keys:
             raise KeyError("No '*_to_embedded' fields found in documents")
 
@@ -195,6 +192,7 @@ class QdrantVectorDB:
             documents: Sequence[Dict[str, Any]],
             embedding_keys: set[str],
             vectors_config: Dict[str, VectorParams],
+            only_code: bool,
     ) -> list[PointStruct]:
 
         points: list[PointStruct] = []
@@ -203,7 +201,7 @@ class QdrantVectorDB:
         zero_vecs = {k: [0.0] * vectors_config[k].size for k in embedding_keys}
         vectors_by_key: Dict[str, list] = {k: [None] * n for k in embedding_keys}
 
-        def process_key(key: str, is_code: bool): # TODo jsut return normaly ar result and put  vectors_by_key as param
+        def process_key(key: str, is_code: bool):  # TODo jsut return normaly ar result and put  vectors_by_key as param
             items: list[tuple[int, str]] = []
             for i, doc in enumerate(documents):
                 v = doc.get(key)
@@ -237,7 +235,8 @@ class QdrantVectorDB:
                     vectors_by_key[key][idx] = emb
 
         process_key("code_to_embedded", is_code=True)
-        process_key("doc_to_embedded", is_code=False)
+        if not only_code:
+            process_key("doc_to_embedded", is_code=False)
 
         for i, doc in enumerate(documents):
             metadata = doc.get("metadata", {})


### PR DESCRIPTION
- Add confirmation before deleting and rebuilding the DB.
- Remove embedding documents by default. Keep a config flag to enable them.
- Add Voyager as an embedding provider and a config option to use it.
- Fix redundant re-embedding when diversity is enabled in RAG search by deduplicating items before embedding.
- Simplify the OpenAI embedding wrapper.
- Add a manual guard to skip embedding files that exceed configured limits (max tokens and/or max size in KB).